### PR TITLE
Provide online developer workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.com/AmadeusITGroup/workflow-cps-global-lib-http-plugin.svg?branch=master)](https://travis-ci.org/AmadeusITGroup/workflow-cps-global-lib-http-plugin)
 [![codecov](https://codecov.io/gh/AmadeusITGroup/workflow-cps-global-lib-http-plugin/branch/master/graph/badge.svg)](https://codecov.io/gh/AmadeusITGroup/workflow-cps-global-lib-http-plugin)
 [![Join the chat at https://gitter.im/AmadeusITGroup/workflow-cps-global-lib-http-plugin](https://badges.gitter.im/AmadeusITGroup/workflow-cps-global-lib-http-plugin.svg)](https://gitter.im/AmadeusITGroup/workflow-cps-global-lib-http-plugin?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.openshift.io/f/?url=https://gist.githubusercontent.com/benoitf/768727d0984a61a093e5908ae4449627/raw/2b515afd09cc168bbe3d9f8348a2d7715599ae4d/gistfile1.txt)
 
 The current official plugin [workflow-cps-global-lib](https://github.com/jenkinsci/workflow-cps-global-lib-plugin/) does provide a way to retrieve shared libraries through a SCM, such as Git. The goal of this plugin is to provide another way to retrieve shared libraries via the @Library declaration in a Jenkinsfile.
 


### PR DESCRIPTION
Add link to online Eclipse Che workspace

[![Contribute](https://che.openshift.io/factory/resources/factory-contribute.svg)](https://che.openshift.io/f/?url=https://gist.githubusercontent.com/benoitf/768727d0984a61a093e5908ae4449627/raw/2b515afd09cc168bbe3d9f8348a2d7715599ae4d/gistfile1.txt)

![image](https://user-images.githubusercontent.com/436777/68527144-123ce080-02e4-11ea-841b-21a55b84c9e9.png)

There are two workspace commands : build and run (from the workspace panel)

These tasks are also available with command palette (F1/run tasks...)