### PR TITLE
Fix a flaky test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-assertj</artifactId>
+      <version>2.9.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-cps-global-lib</artifactId>
     </dependency>

--- a/src/test/java/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest.java
+++ b/src/test/java/com/amadeus/jenkins/plugins/workflow/libs/ConfigurationRoundtripTest.java
@@ -12,6 +12,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.recipes.LocalData;
+import org.xmlunit.assertj.XmlAssert;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -74,17 +75,7 @@ public class ConfigurationRoundtripTest {
         j.configRoundtrip();
         String currentConfig = getConfig();
 
-        String message = "Your config format changed. If it is intentional and necessary:\n";
-        message += " - update this test with new test data that reflects your new data format\n";
-        message += " - create test to make sure that new code can cope with old data format" +
-                " (testConfigurationRoundtripXXX)";
-        message += "\n\n";
-        message += "Old config:\n" + previousConfig;
-        message += "\n\n";
-        message += "New config:\n" + currentConfig;
-        message += "\n\n";
-
-        assertThat(previousConfig).withFailMessage(message).isXmlEqualTo(currentConfig);
+        XmlAssert.assertThat(previousConfig).and(currentConfig).ignoreChildNodesOrder().areSimilar();
     }
 
     private String getConfig() throws IOException {


### PR DESCRIPTION
This PR is to fix a flaky test `com.amadeus.jenkins.plugins.workflow.libs.ConfigurationRoundtripTest#testFormatDidNotChange`.

### Reproduce test failures
- Run the following command to reproduce test failures:
```
mvn  edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=com.amadeus.jenkins.plugins.workflow.libs.ConfigurationRoundtripTest#testFormatDidNotChange
```
- We see the following failure:
```
[ERROR] Failures: 
[ERROR]   ConfigurationRoundtripTest.testFormatDidNotChange:87 Your config format changed. If it is intentional and necessary:
 - update this test with new test data that reflects your new data format
 - create test to make sure that new code can cope with old data format (testConfigurationRoundtripXXX)

Old config:
<?xml version='1.1' encoding='UTF-8'?>
<org.jenkinsci.plugins.workflow.libs.GlobalLibraries>
  <libraries>
    <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
      <name>foo</name>
      <retriever class="com.amadeus.jenkins.plugins.workflow.libs.HttpRetriever">
        <httpURL>http://example.com/</httpURL>
        <credentialsId>someCredentials</credentialsId>
        <preemptiveAuth>true</preemptiveAuth>
      </retriever>
      <implicit>false</implicit>
      <allowVersionOverride>true</allowVersionOverride>
      <includeInChangesets>true</includeInChangesets>
    </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
  </libraries>
</org.jenkinsci.plugins.workflow.libs.GlobalLibraries>

New config:
<?xml version='1.1' encoding='UTF-8'?>
<org.jenkinsci.plugins.workflow.libs.GlobalLibraries>
  <libraries>
    <org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
      <retriever class="com.amadeus.jenkins.plugins.workflow.libs.HttpRetriever">
        <preemptiveAuth>true</preemptiveAuth>
        <credentialsId>someCredentials</credentialsId>
        <httpURL>http://example.com/</httpURL>
      </retriever>
      <implicit>false</implicit>
      <includeInChangesets>true</includeInChangesets>
      <allowVersionOverride>true</allowVersionOverride>
      <name>foo</name>
    </org.jenkinsci.plugins.workflow.libs.LibraryConfiguration>
  </libraries>
</org.jenkinsci.plugins.workflow.libs.GlobalLibraries>
```
### Root cause and fix
In line 87, the assertion assumes all the nodes in `xml` are in an consistent order, but actually the order can be non-deterministic. To fix it, we can use ` XmlAssert` to assert two `xml` strings have same content but ignoring orders.
